### PR TITLE
Fixed Block error with battery in Unknown state.

### DIFF
--- a/src/Blocks/Battery.hs
+++ b/src/Blocks/Battery.hs
@@ -93,7 +93,8 @@ getAcpiBatteryState = do
   let parsed = tail . T.splitOn " " . T.filter (/=',') $ acpi
       state = parsed !! 1
       percent = parsePercent (parsed !! 2)
-      time = if state == "Full"
+      time = if state == "Unknown" then ""
+             else if state == "Full"
              || (percent == 100)
              || (/=':') `T.all` (parsed !! 3)
              then "(∞:∞)"


### PR DESCRIPTION
Some configurations seems to yield Unknown state when battery is plugged + fully charged.
acpi returns too few parts of text in this case so the block crashed at `parsed !! 3`